### PR TITLE
watch out for properties named 'length'

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = function keyedArray (array) {
 
   array.forEach(element => {
     var identifier = element.name || element.id
-    if (identifier) array[identifier] = element
+    if (identifier && identifier !== 'length') array[identifier] = element
 
     if (element && typeof element === 'object') {
       Object.keys(element).forEach(function (e) {


### PR DESCRIPTION
This was an interesting one to debug. `length` is not a mutable property of objects:

```js
{name: 'length'}
```

So if we come across this value, just skip it.